### PR TITLE
[DoriKit][Filter] Filter V3

### DIFF
--- a/DoriKit/Filter/DoriFilter.swift
+++ b/DoriKit/Filter/DoriFilter.swift
@@ -14,11 +14,18 @@
 
 import Foundation
 
-public protocol DoriFilter {
+public protocol DoriFilter: Equatable, Hashable {
+    init()
+    
     associatedtype Element
     func filter(_ elements: [Element]) -> [Element]
     
     associatedtype Key: DoriFilterKey
+}
+extension DoriFilter {
+    public var isFiltered: Bool {
+        self == .init()
+    }
 }
 
 public protocol DoriFilterKey: RawRepresentable, CaseIterable, Comparable, Hashable {

--- a/DoriKit/Filter/FilterCacheManager.swift
+++ b/DoriKit/Filter/FilterCacheManager.swift
@@ -1,0 +1,71 @@
+//===---*- Greatdori! -*---------------------------------------------------===//
+//
+// FilterCacheManager.swift
+//
+// This source file is part of the Greatdori! open source project
+//
+// Copyright (c) 2025 the Greatdori! project authors
+// Licensed under Apache License v2.0
+//
+// See https://greatdori.memz.top/LICENSE.txt for license information
+// See https://greatdori.memz.top/CONTRIBUTORS.txt for the list of Greatdori! project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+internal final class FilterCacheManager: Sendable {
+    internal static let shared = FilterCacheManager()
+    
+    nonisolated(unsafe) private var allCache = _FilterCache()
+    private let lock = NSLock()
+    
+    internal func writeCardCache(_ cardsList: [DoriAPI.Card.PreviewCard]?) {
+        lock.lock()
+        defer { lock.unlock() }
+        if cardsList != nil {
+            unsafe allCache.cardsList = cardsList
+            unsafe allCache.cardsDict.removeAll()
+            if let cards = cardsList {
+                for card in cards {
+                    unsafe allCache.cardsDict[card.id] = card
+                }
+            }
+        }
+    }
+    
+    internal func writeBandsList(_ bandsList: [DoriAPI.Band.Band]?) {
+        lock.lock()
+        defer { lock.unlock() }
+        if bandsList != nil {
+            unsafe allCache.bandsList = bandsList
+        }
+    }
+    
+    internal func writeCharactersList(_ charactersList: [DoriAPI.Character.PreviewCharacter]?) {
+        lock.lock()
+        defer { lock.unlock() }
+        if charactersList != nil {
+            unsafe allCache.charactersList = charactersList
+        }
+    }
+    
+    internal func read() -> _FilterCache {
+        lock.lock()
+        defer { lock.unlock() }
+        return unsafe allCache
+    }
+    
+    internal func erase() {
+        lock.lock()
+        defer { lock.unlock() }
+        unsafe allCache = .init()
+    }
+}
+
+public struct _FilterCache {
+    internal var cardsList: [DoriAPI.Card.PreviewCard]?
+    internal var cardsDict: [Int: DoriAPI.Card.PreviewCard] = [:]
+    internal var bandsList: [DoriAPI.Band.Band]?
+    internal var charactersList: [DoriAPI.Character.PreviewCharacter]?
+}

--- a/DoriKit/Filter/FilterSupportingTypes.swift
+++ b/DoriKit/Filter/FilterSupportingTypes.swift
@@ -1,0 +1,96 @@
+//===---*- Greatdori! -*---------------------------------------------------===//
+//
+// FilterSupportingTypes.swift
+//
+// This source file is part of the Greatdori! open source project
+//
+// Copyright (c) 2025 the Greatdori! project authors
+// Licensed under Apache License v2.0
+//
+// See https://greatdori.memz.top/LICENSE.txt for license information
+// See https://greatdori.memz.top/CONTRIBUTORS.txt for the list of Greatdori! project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public enum DoriFilterCharacter: Int, Sendable, CaseIterable, Hashable, Codable {
+    // Poppin'Party
+    case kasumi = 1
+    case tae
+    case rimi
+    case saya
+    case arisa
+    
+    // Afterglow
+    case ran
+    case moca
+    case himari
+    case tomoe
+    case tsugumi
+    
+    // Hello, Happy World!
+    case kokoro
+    case kaoru
+    case hagumi
+    case kanon
+    case misaki
+    
+    // Pastel＊Palettes
+    case aya
+    case hina
+    case chisato
+    case maya
+    case eve
+    
+    // Roselia
+    case yukina
+    case sayo
+    case lisa
+    case ako
+    case rinko
+    
+    // Morfonica
+    case mashiro
+    case toko
+    case nanami
+    case tsukushi
+    case rui
+    
+    // RAISE A SUILEN
+    case rei
+    case rokka
+    case masuki
+    case reona
+    case chiyu
+    
+    // MyGO!!!!!
+    case tomori
+    case anon
+    case rana
+    case soyo
+    case taki
+    
+    /// Localized character name.
+    @inline(never)
+    public var name: String {
+        NSLocalizedString("CHARACTER_NAME_ID_" + String(self.rawValue), bundle: #bundle, comment: "")
+    }
+}
+
+@frozen
+public enum DoriFilterTimelineStatus: Int, CaseIterable, Hashable, Codable {
+    case ended
+    case ongoing
+    case upcoming
+    
+    /// Localized description text for status.
+    @inline(never)
+    internal var localizedString: String {
+        switch self {
+        case .ended: String(localized: "TIMELINE_STATUS_ENDED", bundle: #bundle)
+        case .ongoing: String(localized: "TIMELINE_STATUS_ONGOING", bundle: #bundle)
+        case .upcoming: String(localized: "TIMELINE_STATUS_UPCOMING", bundle: #bundle)
+        }
+    }
+}

--- a/DoriKit/Filter/GachaFilter.swift
+++ b/DoriKit/Filter/GachaFilter.swift
@@ -1,0 +1,123 @@
+//===---*- Greatdori! -*---------------------------------------------------===//
+//
+// GachaFilter.swift
+//
+// This source file is part of the Greatdori! open source project
+//
+// Copyright (c) 2025 the Greatdori! project authors
+// Licensed under Apache License v2.0
+//
+// See https://greatdori.memz.top/LICENSE.txt for license information
+// See https://greatdori.memz.top/CONTRIBUTORS.txt for the list of Greatdori! project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public struct GachaFilter {
+    public var attribute: Set<DoriAPI.Attribute> = .init(DoriAPI.Attribute.allCases)
+    public var character: Set<DoriFilterCharacter> = .init(DoriFilterCharacter.allCases)
+    public var characterRequiresMatchAll: Bool = false
+    public var server: Set<DoriAPI.Locale> = .init(DoriAPI.Locale.allCases)
+    public var released: Set<Bool> = [false, true]
+    public var type: Set<DoriAPI.Gacha.GachaType> = .init(DoriAPI.Gacha.GachaType.allCases)
+    public var timelineStatus: Set<DoriFilterTimelineStatus> = .init(DoriFilterTimelineStatus.allCases)
+    
+    public init() {}
+    public init(
+        attribute: Set<DoriAPI.Attribute>,
+        character: Set<DoriFilterCharacter>,
+        characterRequiresMatchAll: Bool,
+        server: Set<DoriAPI.Locale>,
+        released: Set<Bool>,
+        type: Set<DoriAPI.Gacha.GachaType>,
+        timelineStatus: Set<DoriFilterTimelineStatus>
+    ) {
+        self.attribute = attribute
+        self.character = character
+        self.characterRequiresMatchAll = characterRequiresMatchAll
+        self.server = server
+        self.released = released
+        self.type = type
+        self.timelineStatus = timelineStatus
+    }
+}
+
+extension GachaFilter: DoriFilter {
+    public typealias Element = DoriAPI.Gacha.PreviewGacha
+    public func filter(_ elements: [Element]) -> [Element] {
+        guard self.isFiltered else { return elements }
+        guard let cards = FilterCacheManager.shared.read().cardsList else { return elements }
+        
+        return elements.filter {
+            self.type.contains($0.type)
+        }.filter { gacha in
+            if self.attribute == Set(DoriAPI.Attribute.allCases) {
+                return true
+            }
+            let cards = cards.filter { gacha.newCards.contains($0.id) }
+            return self.attribute.contains { cards.map { $0.attribute }.contains($0) }
+        }.filter { gacha in
+            if self.character == Set(DoriFilterCharacter.allCases) {
+                return true
+            }
+            let cards = cards.filter { gacha.newCards.contains($0.id) }
+            if self.characterRequiresMatchAll {
+                return self.character.allSatisfy { cards.map { $0.characterID }.contains($0.rawValue) }
+            } else {
+                return self.character.contains { cards.map { $0.characterID }.contains($0.rawValue) }
+            }
+        }.filter { gacha in
+            for status in self.released {
+                for locale in self.server {
+                    if status {
+                        if (gacha.publishedAt.forLocale(locale) ?? dateOfYear2100) < .now {
+                            return true
+                        }
+                    } else {
+                        if (gacha.publishedAt.forLocale(locale) ?? .init(timeIntervalSince1970: 0)) > .now {
+                            return true
+                        }
+                    }
+                }
+            }
+            return false
+        }.filter { gacha in
+            for timelineStatus in self.timelineStatus {
+                let result = switch timelineStatus {
+                case .ended:
+                    (gacha.closedAt.forPreferredLocale() ?? dateOfYear2100) < .now
+                case .ongoing:
+                    (gacha.publishedAt.forPreferredLocale() ?? dateOfYear2100) < .now
+                    && (gacha.closedAt.forPreferredLocale() ?? .init(timeIntervalSince1970: 0)) > .now
+                case .upcoming:
+                    (gacha.publishedAt.forPreferredLocale() ?? .init(timeIntervalSince1970: 0)) > .now
+                }
+                if result {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+    
+    public enum Key: Int, DoriFilterKey {
+        case attribute
+        case character
+        case characterRequiresMatchAll
+        case server
+        case type
+        case timelineStatus
+        
+        public var localizedString: String {
+            switch self {
+            case .attribute: String(localized: "FILTER_KEY_ATTRIBUTE", bundle: #bundle)
+            case .character: String(localized: "FILTER_KEY_CHARACTER", bundle: #bundle)
+            case .characterRequiresMatchAll: String(localized: "FILTER_KEY_CHARACTER_REQUIRES_MATCH_ALL", bundle: #bundle)
+            case .server: String(localized: "FILTER_KEY_SERVER", bundle: #bundle)
+            case .type: String(localized: "FILTER_KEY_GACHA_TYPE", bundle: #bundle)
+            case .timelineStatus: String(localized: "FILTER_KEY_TIMELINE_STATUS", bundle: #bundle)
+            }
+        }
+    }
+}

--- a/DoriKit/Frontend/Filters.swift
+++ b/DoriKit/Frontend/Filters.swift
@@ -28,6 +28,7 @@ extension DoriFrontend {
     ///
     /// - SeeAlso:
     ///     Interact with each keys of a filter by ``Key``, which also allows you to build UI for filter.
+    @available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
     public struct Filter: Sendable, Hashable, Codable {
         public var band: Set<Band> = .init(Band.allCases) { didSet { store() } }
         public var bandMatchesOthers: BandMatchesOthers = .includeOthers { didSet { store() } }
@@ -197,6 +198,7 @@ extension DoriFrontend {
     }
 }
 
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter {
     public typealias Attribute = DoriAPI.Attribute
     public typealias Rarity = Int
@@ -450,21 +452,25 @@ extension DoriFrontend.Filter {
     }
 }
 
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Key: Identifiable {
     public var id: Int { self.rawValue }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension Set<DoriFrontend.Filter.Key> {
     @inlinable
     public func sorted() -> [DoriFrontend.Filter.Key] {
         self.sorted { $0.rawValue < $1.rawValue }
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension Array<DoriFrontend.Filter.Key> {
     @inlinable
     public func sorted() -> [DoriFrontend.Filter.Key] {
         self.sorted { $0.rawValue < $1.rawValue }
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Key {
     @inline(never)
     public var localizedString: String {
@@ -492,12 +498,14 @@ extension DoriFrontend.Filter.Key {
     }
 }
 
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Key: Comparable {
     @inlinable
     public static func < (lhs: DoriFrontend.Filter.Key, rhs: DoriFrontend.Filter.Key) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter: MutableCollection {
     public typealias Element = AnyHashable
     
@@ -607,6 +615,7 @@ extension DoriFrontend.Filter: MutableCollection {
     }
 }
 
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter {
     @_typeEraser(_AnySelectable)
     public protocol _Selectable: Hashable {
@@ -637,6 +646,7 @@ extension DoriFrontend.Filter {
         public var selectorImageURL: URL? { _selectorImageURL }
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter._Selectable {
     public var selectorImageURL: URL? { nil }
     
@@ -644,6 +654,7 @@ extension DoriFrontend.Filter._Selectable {
         self.selectorText == selectable.selectorText
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Band: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.name
@@ -656,6 +667,7 @@ extension DoriFrontend.Filter.Band: DoriFrontend.Filter._Selectable {
         }
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Attribute: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.rawValue.uppercased()
@@ -664,6 +676,7 @@ extension DoriFrontend.Filter.Attribute: DoriFrontend.Filter._Selectable {
         .init(string: "https://bestdori.com/res/icon/\(self.rawValue).svg")!
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Rarity: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         String(self)
@@ -672,6 +685,7 @@ extension DoriFrontend.Filter.Rarity: DoriFrontend.Filter._Selectable {
         .init(string: "https://bestdori.com/res/icon/star_\(self).png")!
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Character: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.name
@@ -680,12 +694,14 @@ extension DoriFrontend.Filter.Character: DoriFrontend.Filter._Selectable {
         .init(string: "https://bestdori.com/res/icon/chara_icon_\(self.rawValue).png")!
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension Bool: DoriFrontend.Filter._Selectable {
     @inline(never)
     public var selectorText: String {
         self ? String(localized: "FILTER_MATCH_ALL", bundle: #bundle) : String(localized: "FILTER_MATCH_ANY", bundle: #bundle)
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Server: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.rawValue.uppercased()
@@ -694,47 +710,56 @@ extension DoriFrontend.Filter.Server: DoriFrontend.Filter._Selectable {
         self.iconImageURL
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.ReleaseStatus: DoriFrontend.Filter._Selectable {
     @inline(never)
     public var selectorText: String {
         self.boolValue ? String(localized: "FILTER_RELEASED_YES", bundle: #bundle) : String(localized: "FILTER_RELEASED_NO", bundle: #bundle)
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.CardType: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.EventType: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.GachaType: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.SongType: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.LoginCampaignType: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.ComicType: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Skill: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.maximumDescription.forPreferredLocale() ?? ""
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension Optional<DoriFrontend.Filter.Skill>: DoriFrontend.Filter._Selectable {
     @inline(never)
     public var selectorText: String {
@@ -745,21 +770,25 @@ extension Optional<DoriFrontend.Filter.Skill>: DoriFrontend.Filter._Selectable {
         }
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.TimelineStatus: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Sort.Keyword: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Sort: DoriFrontend.Filter._Selectable {
     public var selectorText: String {
         self.keyword.localizedString
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Key {
     /// Get a selector for key.
     ///
@@ -915,9 +944,12 @@ extension DoriFrontend.Filter.Key {
         case multiple
     }
 }
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Key.SelectorItem: Equatable where T: Equatable {}
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Key.SelectorItem: Hashable where T: Hashable {}
 
+@available(*, deprecated, message: "Use filters conform to DoriFilter instead.")
 extension DoriFrontend.Filter.Band {
     internal func asFullBand() -> DoriFrontend.Filter.FullBand {
         return DoriFrontend.Filter.FullBand(rawValue: self.rawValue)!

--- a/Greatdori.xcodeproj/project.pbxproj
+++ b/Greatdori.xcodeproj/project.pbxproj
@@ -218,6 +218,9 @@
 		8CBC1BE12E340AD8004023F7 /* CostumeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CBC1BE02E340AD4004023F7 /* CostumeListView.swift */; };
 		8CC046DC2E6C8F63009FDC13 /* AppFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC046DB2E6C8F5D009FDC13 /* AppFlags.swift */; };
 		8CC047572E6D62CD009FDC13 /* DoriFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC047562E6D62C9009FDC13 /* DoriFilter.swift */; };
+		8CC047592E6D6BF2009FDC13 /* GachaFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC047582E6D6BEE009FDC13 /* GachaFilter.swift */; };
+		8CC0475B2E6D6F7E009FDC13 /* FilterSupportingTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC0475A2E6D6F78009FDC13 /* FilterSupportingTypes.swift */; };
+		8CC0475D2E6D73E9009FDC13 /* FilterCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC0475C2E6D73E6009FDC13 /* FilterCacheManager.swift */; };
 		8CD13F752E2FDC4A00673E15 /* NavigationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD13F742E2FDC4700673E15 /* NavigationListView.swift */; };
 		8CD13FAE2E2FE2BF00673E15 /* Band.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD13FA12E2FE2BF00673E15 /* Band.swift */; };
 		8CD13FAF2E2FE2BF00673E15 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD13FA22E2FE2BF00673E15 /* Card.swift */; };
@@ -841,6 +844,9 @@
 		8CBC1BE02E340AD4004023F7 /* CostumeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostumeListView.swift; sourceTree = "<group>"; };
 		8CC046DB2E6C8F5D009FDC13 /* AppFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlags.swift; sourceTree = "<group>"; };
 		8CC047562E6D62C9009FDC13 /* DoriFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoriFilter.swift; sourceTree = "<group>"; };
+		8CC047582E6D6BEE009FDC13 /* GachaFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GachaFilter.swift; sourceTree = "<group>"; };
+		8CC0475A2E6D6F78009FDC13 /* FilterSupportingTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSupportingTypes.swift; sourceTree = "<group>"; };
+		8CC0475C2E6D73E6009FDC13 /* FilterCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCacheManager.swift; sourceTree = "<group>"; };
 		8CD13F742E2FDC4700673E15 /* NavigationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationListView.swift; sourceTree = "<group>"; };
 		8CD13FA12E2FE2BF00673E15 /* Band.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Band.swift; sourceTree = "<group>"; };
 		8CD13FA22E2FE2BF00673E15 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
@@ -1661,6 +1667,9 @@
 			isa = PBXGroup;
 			children = (
 				8CC047562E6D62C9009FDC13 /* DoriFilter.swift */,
+				8CC0475A2E6D6F78009FDC13 /* FilterSupportingTypes.swift */,
+				8CC0475C2E6D73E6009FDC13 /* FilterCacheManager.swift */,
+				8CC047582E6D6BEE009FDC13 /* GachaFilter.swift */,
 			);
 			path = Filter;
 			sourceTree = "<group>";
@@ -2554,6 +2563,7 @@
 				8C923D7A2E3046D0003AFC0A /* FrontendCharacter.swift in Sources */,
 				8CE186AF2E535DE0009C1C87 /* Asset.swift in Sources */,
 				8C923D892E305237003AFC0A /* FrontendEvent.swift in Sources */,
+				8CC0475B2E6D6F7E009FDC13 /* FilterSupportingTypes.swift in Sources */,
 				8CD13FB02E2FE2BF00673E15 /* Character.swift in Sources */,
 				8CD13FB12E2FE2BF00673E15 /* Costume.swift in Sources */,
 				8C923D9D2E313B4A003AFC0A /* FrontendCard.swift in Sources */,
@@ -2563,6 +2573,7 @@
 				8C2CCD472E3E07AC0014189F /* DoriEmoji.swift in Sources */,
 				8C94744A2E35AB84003A90B4 /* DoriCache.swift in Sources */,
 				8CBC1BD32E32B898004023F7 /* InMemoryCaches.swift in Sources */,
+				8CC0475D2E6D73E9009FDC13 /* FilterCacheManager.swift in Sources */,
 				8CD13FC52E2FE2BF00673E15 /* Color+.swift in Sources */,
 				8CB76C862E60171E00229F6F /* Macros.swift in Sources */,
 				8CBC1BDF2E3408AB004023F7 /* FrontendCostume.swift in Sources */,
@@ -2579,6 +2590,7 @@
 				E9EFF2B82E61BEAB00991940 /* MatchedFilters.swift in Sources */,
 				8CBC1BD12E32B5BA004023F7 /* Constructor.swift in Sources */,
 				8C8E43EA2E5D2AC4005590F0 /* OfflineAssetDispatch.swift in Sources */,
+				8CC047592E6D6BF2009FDC13 /* GachaFilter.swift in Sources */,
 				8C8E43EC2E5D3118005590F0 /* OfflineNetworking.swift in Sources */,
 				8C3264042E3B760100081F4F /* PreCache.swift in Sources */,
 				8CD13FC62E2FE2BF00673E15 /* Logger.swift in Sources */,


### PR DESCRIPTION
# Filter V3

## Introduction

The current filter may confusing for developers and is likely to be misused. This pull request introduces a new filter system which makes filtering in DoriFrontend more expressible and easy to use.

## Motivation

The current filter in DoriFrontend (`DoriFrontend.Filter`) doesn't express anything about availability for keys so that developers depend on documentation for information about key availability, which is not a good API design.

Also, we're using too many existential types and type erasers in current filter, which reduce performance and require callers to write code that is hard to understand. Though the `Array.filter(withDoriFilter:)` in the previous filter update allows us to filter results without a new network request from `list(filter:)` functions, it's also hard to create or modify a filter to a status we need.

Consider the following code from current Greatdori! watchOS app:

```swift
if var filterSet = filter[key] as? Set<AnyHashable> {
    if filterSet.contains(item.item.value) {
        filterSet.remove(item.item.value)
    } else {
        filterSet.insert(item.item.value)
    }
    filter[key] = filterSet
} else {
    os_log(.fault, "\(type(of: filter[key])) is not Set")
}
```

We have to cast `filter[key]` to `Set<AnyHashable>`, which is not expressible and produces complex code.

## Solution

Introduce a new filter system *DoriFilter*, in the top-level. It's no longer fit to put it in DoriFrontend because this makes it harder to be called, and this is something we use frequently.

We create a protocol `DoriFilter` as the base of our new system, then create individual filter structures for each data categories. Filtering logics are implemented by each filters themselves.

All the `list(filter: DoriFrontend.Filter)` functions will be deprecated, and new `list()` will be available, which only fetch data. The `Array.filter(withDoriFilter:)` will also be deprecated and new corresponding functions will be available in each `Preview`-types.

Sorting will be separated from filter since they're actually not the same, we'll introduce `sorted(byDoriSorter:)` functions for sorting.

## Source compatibility

The old filters (v1 & v2) will be deprecated, which is not considered to be a source incompatible change.

## ABI compatibility

Since old filters will be deprecated and not changed, there's no breaking change for ABI.