### PR TITLE
Fix: Address list item disappearance on iOS 26 by gating zoom transitions

### DIFF
--- a/Greatdori/Info/Character/CharacterSearchView.swift
+++ b/Greatdori/Info/Character/CharacterSearchView.swift
@@ -54,12 +54,7 @@ struct CharacterSearchView: View {
                                                 CharacterDetailView(id: char.id, allCharacters: allCharacters)
                                                 #if !os(macOS)
                                                     .wrapIf(true, in: { content in
-                                                        if #available(iOS 18.0, *) {
-                                                            content
-                                                                .navigationTransition(.zoom(sourceID: char.id, in: detailNavigation))
-                                                        } else {
-                                                            content
-                                                        }
+                                                        content.applyZoomDestinationFix(id: char.id, in: detailNavigation)
                                                     })
                                                 #endif
                                             }, label: {
@@ -67,12 +62,7 @@ struct CharacterSearchView: View {
                                             })
                                             .buttonStyle(.plain)
                                             .wrapIf(true, in: { content in
-                                                if #available(iOS 18.0, macOS 15.0, *) {
-                                                    content
-                                                        .matchedTransitionSource(id: char.id, in: detailNavigation)
-                                                } else {
-                                                    content
-                                                }
+                                                content.applyZoomSourceFix(id: char.id, in: detailNavigation)
                                             })
                                             .accessibilityLabel(char.characterName.forPreferredLocale() ?? "")
                                         }

--- a/Greatdori/Methods/ViewModifiers.swift
+++ b/Greatdori/Methods/ViewModifiers.swift
@@ -508,3 +508,40 @@ private struct VariadicModifier<V: View>: ViewModifier {
         }
     }
 }
+
+// Fix #22
+extension View {
+    func applyZoomSourceFix<ID: Hashable>(id: ID, in namespace: Namespace.ID) -> some View {
+        modifier(ZoomSourceFixModifier(id: id, namespace: namespace))
+    }
+    
+    func applyZoomDestinationFix<ID: Hashable>(id: ID, in namespace: Namespace.ID) -> some View {
+        modifier(ZoomDestinationFixModifier(id: id, namespace: namespace))
+    }
+}
+private struct ZoomSourceFixModifier<ID: Hashable>: ViewModifier {
+    var id: ID
+    var namespace: Namespace.ID
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+        } else if #available(iOS 18.0, macOS 15.0, *) {
+            content.matchedTransitionSource(id: id, in: namespace)
+        } else {
+            content
+        }
+    }
+}
+private struct ZoomDestinationFixModifier<ID: Hashable>: ViewModifier {
+    var id: ID
+    var namespace: Namespace.ID
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+        } else if #available(iOS 18.0, *) {
+            content.navigationTransition(.zoom(sourceID: id, in: namespace))
+        } else {
+            content
+        }
+    }
+}

--- a/Greatdori/UI Basics/InfoBases.swift
+++ b/Greatdori/UI Basics/InfoBases.swift
@@ -463,12 +463,7 @@ struct SearchViewBase<Element: Sendable & Hashable & DoriCacheable & DoriFiltera
             makeDestination(element, elements ?? [])
             #if !os(macOS)
                 .wrapIf(true) { content in
-                    if #available(iOS 18.0, *) {
-                        content
-                            .navigationTransition(.zoom(sourceID: element.hashValue, in: navigationAnimationNamespace))
-                    } else {
-                        content
-                    }
+                    content.applyZoomDestinationFix(id: element.hashValue, in: navigationAnimationNamespace)
                 }
             #endif
         }
@@ -562,12 +557,7 @@ struct SearchViewBase<Element: Sendable & Hashable & DoriCacheable & DoriFiltera
                     isCustomGroupBoxActive = isActive
                 }
                 .wrapIf(true) { content in
-                    if #available(iOS 18.0, macOS 15.0, *) {
-                        content
-                            .matchedTransitionSource(id: element.hashValue, in: navigationAnimationNamespace)
-                    } else {
-                        content
-                    }
+                    content.applyZoomSourceFix(id: element.hashValue, in: navigationAnimationNamespace)
                 }
         }
     }


### PR DESCRIPTION
This pull request addresses a UI regression found in **iOS 26** where list items (Characters, Costumes, and Cards) would disappear from the collection view after navigating back from a detail page using the `.zoom` transition.

Resolves #22.
