### PR TITLE
Fix Greatdori not appearing in the macOS widget list and add a script for quickly replacing signing IDs

### DIFF
--- a/Greatdori.xcodeproj/project.pbxproj
+++ b/Greatdori.xcodeproj/project.pbxproj
@@ -3206,6 +3206,13 @@
 					"@executable_path/../../Frameworks",
 					/Library/Frameworks,
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
+					/Library/Frameworks,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.2.0;
 				OTHER_SWIFT_FLAGS = "-enable-experimental-feature BuiltinModule";
@@ -3250,6 +3257,13 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
+					/Library/Frameworks,
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
 					/Library/Frameworks,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
@@ -3299,6 +3313,13 @@
 					"@executable_path/../../Frameworks",
 					/Library/Frameworks,
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
+					/Library/Frameworks,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.2.0;
 				OTHER_SWIFT_FLAGS = "-enable-experimental-feature BuiltinModule";
@@ -3344,6 +3365,13 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
+					/Library/Frameworks,
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
 					/Library/Frameworks,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
@@ -3590,9 +3618,9 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = B57D8PP775;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3643,9 +3671,9 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = B57D8PP775;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3696,9 +3724,9 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = B57D8PP775;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3748,9 +3776,9 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = B57D8PP775;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4249,6 +4277,13 @@
 					"@executable_path/../../Frameworks",
 					/Library/Frameworks,
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
+					/Library/Frameworks,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.2.0;
 				OTHER_SWIFT_FLAGS = "-enable-experimental-feature BuiltinModule";
@@ -4392,9 +4427,9 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = B57D8PP775;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4666,6 +4701,13 @@
 					"@executable_path/../../Frameworks",
 					/Library/Frameworks,
 				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
+					/Library/Frameworks,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.2.0;
 				OTHER_SWIFT_FLAGS = "-enable-experimental-feature BuiltinModule";
@@ -4828,9 +4870,9 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = B57D8PP775;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/utils/configure-signing
+++ b/utils/configure-signing
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+OLD_TEAM_ID = "B57D8PP775"
+OLD_BASE_BUNDLE_ID = "com.memz233.Greatdori"
+OLD_WIDGET_GROUP = "group.memz233.Greatdori.Widgets"
+OLD_MAIN_GROUP = "group.com.memz233.Greatdori"
+
+TEXT_SUFFIXES = {
+    ".entitlements",
+    ".pbxproj",
+    ".plist",
+    ".swift",
+}
+
+
+def iter_candidate_files(project_root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in project_root.rglob("*")
+        if ".git" not in path.parts and path.is_file() and path.suffix in TEXT_SUFFIXES
+    )
+
+
+def build_replacements(args: argparse.Namespace) -> list[tuple[str, str]]:
+    custom_ids = (
+        (args.team_id, OLD_TEAM_ID),
+        (args.widget_group, OLD_WIDGET_GROUP),
+        (args.main_group, OLD_MAIN_GROUP),
+        (args.base_bundle_id, OLD_BASE_BUNDLE_ID),
+    )
+    if args.restore:
+        replacements = custom_ids
+    else:
+        replacements = [(old, new) for new, old in custom_ids]
+    return sorted(replacements, key=lambda pair: len(pair[0]), reverse=True)
+
+
+def apply_replacements(
+    content: str, replacements: list[tuple[str, str]]
+) -> tuple[str, int]:
+    updated = content
+    count = 0
+    for old, new in replacements:
+        matches = updated.count(old)
+        if matches:
+            updated = updated.replace(old, new)
+            count += matches
+    return updated, count
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Replace Greatdori signing identifiers for local builds.",
+    )
+    parser.add_argument("--team-id", required=True)
+    parser.add_argument("--base-bundle-id", required=True)
+    parser.add_argument("--widget-group", required=True)
+    parser.add_argument("--main-group", required=True)
+    parser.add_argument(
+        "--restore",
+        action="store_true",
+        help="replace the provided identifiers with the original project identifiers",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    project_root = PROJECT_ROOT.resolve()
+    if not (project_root / "Greatdori.xcodeproj").exists():
+        print(f"Not a Greatdori checkout: {project_root}", file=sys.stderr)
+        return 1
+
+    replacements = build_replacements(args)
+    changed_files: list[tuple[Path, int]] = []
+
+    for path in iter_candidate_files(project_root):
+        try:
+            original = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        updated, replacement_count = apply_replacements(original, replacements)
+        if updated == original:
+            continue
+
+        changed_files.append((path, replacement_count))
+        if not args.dry_run:
+            path.write_text(updated, encoding="utf-8")
+
+    mode = "Would update" if args.dry_run else "Updated"
+    print(f"{mode} {len(changed_files)} file(s) under {project_root}")
+    for path, replacement_count in changed_files:
+        print(f"- {path.relative_to(project_root)}: {replacement_count} replacement(s)")
+
+    if args.dry_run:
+        print("Dry run only. Re-run without --dry-run to apply changes.")
+    if not changed_files:
+        print("No matching identifiers found.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR fixes the issue where Greatdori does not appear in the widget list on macOS. When I was using the App Store version of Greatdori, I found that it did not appear in the macOS widget list, while it worked normally on iOS.

I pulled the code locally and replaced all IDs with my own IDs to debug the widget extension (`Greatdori Widgets`). When launching it in debug mode, it reported the following error:

```
dyld[60962]: Library not loaded: @rpath/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections
  Referenced from: <DAF7F14C-4342-3DC4-9481-088CA2FBD287> /Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Contents/MacOS/Greatdori Widgets.debug.dylib
  Reason: tried: '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (code signature in <FE7A6F25-BCB9-32A0-A6B6-5DA67E2613A9> '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug-watchos/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/PackageFrameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug-watchos/PackageFrameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/usr/lib/swift/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file, not in dyld cache), '/System/Volumes/Preboot/Cryptexes/OS/usr/lib/swift/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/PackageFrameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/PackageFrameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Contents/MacOS/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Library/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Library/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Contents/MacOS/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/PackageFrameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/PackageFrameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Contents/MacOS/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Library/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Library/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Contents/MacOS/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/PackageFrameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/PackageFrameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Contents/MacOS/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Users/zhelearn/Library/Developer/Xcode/DerivedData/Greatdori-eculjsnmlpmzezexvbewpkztrokn/Build/Products/Debug/Greatdori!.app/Contents/PlugIns/Greatdori Widgets.appex/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/Library/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Library/Frameworks/BuiltinCardCollections.framework/Versions/A/BuiltinCardCollections' (no such file)
Type: stdio
```

I found that these two libraries are dynamically linked, but they are only embedded into the app and not into the widget extension. According to Apple’s guidelines, widget extensions also cannot embed dynamic libraries.

Then I tried adding the app’s `Frameworks` directory (`@executable_path/../../../../Frameworks`) to `LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]`. After rebuilding and running again, the widget extension could be debugged successfully, and Greatdori also appeared in the macOS widget list.

<img width="1050" height="563" alt="Screenshot2026-04-30 23 34 50" src="https://github.com/user-attachments/assets/14ab89c3-8b1c-4908-b6ec-f316e4f35f69" />

And I added a script under `utils` to quickly replace the project IDs and signing configuration for other developers, which is `utils/configure-signing`. For example, I can use it like this:

```bash
utils/configure-signing \
  --team-id 7GPA4WLM3W \
  --base-bundle-id com.zhelearn.Greatdori \
  --widget-group group.zhelearn.Greatdori.Widgets \
  --main-group group.com.zhelearn.Greatdori
```

This makes it possible to quickly replace the related IDs with a developer’s own IDs, which makes development easier for other contributors. To restore the original author’s IDs, just add the `--restore` parameter.

## Tests

- [x] Build passed.
- [x] Debugged locally on my Mac and a physical iPhone. The builds passed and the widgets worked normally.
- [x] Built the Release version using `Greatdori-App-Store`. The build passed and was uploaded to TestFlight.
- [x] Installed Greatdori from TestFlight on both my Mac and physical iPhone. The widget features worked normally and appeared in the widget list on both platforms.