### PR TITLE
Fix memory-related crashes on high difficulty charts and slide rendering issues on macOS

### DIFF
--- a/Greatdori/Shaders/ChartViewer_LongNoteLine.fsh
+++ b/Greatdori/Shaders/ChartViewer_LongNoteLine.fsh
@@ -12,17 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Attributes:
-// float a_is_trailing_end;
-// float a_lane_factor;
-// vec2  a_frame;
+// Uniforms:
+// float u_is_trailing_end;
+// float u_lane_factor;
 
 void main() {
     float transformedX;
-    if (a_is_trailing_end != 0.0) {
-        transformedX = (v_tex_coord.x - v_tex_coord.y) / a_lane_factor + v_tex_coord.y;
+    if (u_is_trailing_end != 0.0) {
+        transformedX = (v_tex_coord.x - v_tex_coord.y) / u_lane_factor + v_tex_coord.y;
     } else {
-        transformedX = (v_tex_coord.x - (1 - a_lane_factor) + v_tex_coord.y) / a_lane_factor - v_tex_coord.y;
+        transformedX = (v_tex_coord.x - (1 - u_lane_factor) + v_tex_coord.y) / u_lane_factor - v_tex_coord.y;
     }
     vec2 texCoords = vec2(transformedX, v_tex_coord.y);
     vec4 texColor = texture2D(u_texture, texCoords);

--- a/Greatdori/Tools/ChartSimulator.swift
+++ b/Greatdori/Tools/ChartSimulator.swift
@@ -246,15 +246,14 @@ private class ChartViewerScene: SKScene {
     }
     
     private class NotesNode: SKNode {
-        static let _longNoteLineShader = {
+        private static func makeLongNoteLineShader(isTrailingEnd: Bool, laneFactor: Float) -> SKShader {
             let shader = SKShader(fileNamed: "ShaderSource/ChartViewer_LongNoteLine.fsh")
-            shader.attributes = [
-                .init(name: "a_is_trailing_end", type: .float),
-                .init(name: "a_lane_factor", type: .float),
-                .init(name: "a_frame", type: .vectorFloat2)
+            shader.uniforms = [
+                .init(name: "u_is_trailing_end", float: isTrailingEnd ? 1 : 0),
+                .init(name: "u_lane_factor", float: laneFactor)
             ]
             return shader
-        }()
+        }
         
         init(
             width: CGFloat,
@@ -357,10 +356,10 @@ private class ChartViewerScene: SKScene {
                             x: max(connectionPosition.x, nextConnectionPosition.x) - node.size.width / 2 + 11,
                             y: nextConnectionPosition.y - node.size.height / 2
                         )
-                        node.shader = ChartViewerScene.NotesNode._longNoteLineShader
-                        node.setValue(.init(float: nextConnectionPosition.x > connectionPosition.x ? 1 : 0), forAttribute: "a_is_trailing_end")
-                        node.setValue(.init(float: Float(laneWidth / node.size.width)), forAttribute: "a_lane_factor")
-                        node.setValue(.init(vectorFloat2: .init(Float(node.size.width), Float(node.size.height))), forAttribute: "a_frame")
+                        node.shader = ChartViewerScene.NotesNode.makeLongNoteLineShader(
+                            isTrailingEnd: nextConnectionPosition.x > connectionPosition.x,
+                            laneFactor: Float(laneWidth / node.size.width)
+                        )
                         addChild(node)
                     }
                     

--- a/Greatdori/Tools/ChartSimulator.swift
+++ b/Greatdori/Tools/ChartSimulator.swift
@@ -28,6 +28,7 @@ struct ChartSimulatorView: View {
     @State private var selectedDifficulty: DoriAPI.Songs.DifficultyType = .easy
     @State private var chart: [DoriAPI.Songs.Chart]?
     @State private var chartSplitCount = 0
+    @State private var chartDisplayID = ""
     @State private var showChartPlayer = false
     @State private var isChartPlayerAssetAvailable = ChartPlayerAssetManager.isAvailable
     @State private var isDownloadingChartPlayerAsset = false
@@ -104,6 +105,7 @@ struct ChartSimulatorView: View {
                                                 .frame(width: 180, height: 500)
                                         }
                                     }
+                                    .id(chartDisplayID)
                                 }
                                 .clipShape(.rect(cornerRadius: 12))
                             } else {
@@ -154,6 +156,9 @@ struct ChartSimulatorView: View {
     
     func loadChart() {
         guard let selectedSong else { return }
+        chart = nil
+        chartSplitCount = 0
+        chartDisplayID = "\(selectedSong.id)-\(selectedDifficulty.rawValue)"
         Task {
             chart = await DoriAPI.Songs.charts(of: selectedSong.id, in: selectedDifficulty)
             guard let chart else {

--- a/Greatdori/Tools/ChartSimulator.swift
+++ b/Greatdori/Tools/ChartSimulator.swift
@@ -27,7 +27,7 @@ struct ChartSimulatorView: View {
     @State private var isSongSelectorPresented = false
     @State private var selectedDifficulty: DoriAPI.Songs.DifficultyType = .easy
     @State private var chart: [DoriAPI.Songs.Chart]?
-    @State private var chartScenes: [ChartViewerScene] = []
+    @State private var chartSplitCount = 0
     @State private var showChartPlayer = false
     @State private var isChartPlayerAssetAvailable = ChartPlayerAssetManager.isAvailable
     @State private var isDownloadingChartPlayerAsset = false
@@ -98,9 +98,9 @@ struct ChartSimulatorView: View {
                         Group {
                             if !showChartPlayer {
                                 ScrollView(.horizontal) {
-                                    HStack(spacing: 0) {
-                                        ForEach(chartScenes, id: \.self) { scene in
-                                            SpriteView(scene: scene)
+                                    LazyHStack(spacing: 0) {
+                                        ForEach(0..<chartSplitCount, id: \.self) { splitIndex in
+                                            ChartViewerPage(chart: chart, splitIndex: splitIndex)
                                                 .frame(width: 180, height: 500)
                                         }
                                     }
@@ -156,15 +156,13 @@ struct ChartSimulatorView: View {
         guard let selectedSong else { return }
         Task {
             chart = await DoriAPI.Songs.charts(of: selectedSong.id, in: selectedDifficulty)
-            if let chart {
-                let chartHeight = (chartLastBeat(chart) + 1) * 100
-                let renderHeight: Double = 500
-                let splitCount = Int(ceil(chartHeight / renderHeight))
-                chartScenes.removeAll()
-                for i in 0..<splitCount {
-                    chartScenes.append(.init(size: .init(width: 180, height: renderHeight), chart: chart, splitIndex: i))
-                }
+            guard let chart else {
+                chartSplitCount = 0
+                return
             }
+            let chartHeight = (chartLastBeat(chart) + 1) * 100
+            let renderHeight: Double = 500
+            chartSplitCount = Int(ceil(chartHeight / renderHeight))
         }
     }
 }
@@ -173,10 +171,38 @@ struct ChartSimulatorView: View {
 // For identifying, Chart Viewer is a plain chart view without any motion,
 // whereas Chart Player is like the one in GBP with moving notes.
 
+private struct ChartViewerPage: View {
+    let chart: [DoriAPI.Songs.Chart]
+    let splitIndex: Int
+    @State private var scene: ChartViewerScene?
+
+    var body: some View {
+        Group {
+            if let scene {
+                SpriteView(scene: scene)
+            } else {
+                Color.clear
+            }
+        }
+        .onAppear {
+            makeSceneIfNeeded()
+        }
+        .onDisappear {
+            scene = nil
+        }
+    }
+
+    private func makeSceneIfNeeded() {
+        guard scene == nil else { return }
+        scene = .init(size: .init(width: 180, height: 500), chart: chart, splitIndex: splitIndex)
+    }
+}
+
 private class ChartViewerScene: SKScene {
     let chart: [DoriAPI.Songs.Chart]
     let splitIndex: Int
     let configuration = ChartViewerConfiguration()
+    private var isRendered = false
     
     init(size: CGSize, chart: [DoriAPI.Songs.Chart], splitIndex: Int) {
         self.chart = chart
@@ -189,6 +215,8 @@ private class ChartViewerScene: SKScene {
     }
     
     override func didMove(to view: SKView) {
+        guard !isRendered else { return }
+        isRendered = true
         self.backgroundColor = .black
         
         let combinedNode = SKNode()


### PR DESCRIPTION
## Problem

In the app's **Tools -> Chart & Simulator** page, if I select a song and choose a higher difficulty, the app crashes immediately. This issue exists for most songs. Easy and Normal difficulties usually display normally on my phone, but Hard or Expert difficulties lead to a crash.

I tried debugging with Xcode. There is no error stack trace, only a crash notification as follows:

```
The process has been terminated by the operating system because it is using too much memory.
Domain: IDEDebugSessionErrorDomain
Code: 11
Failure Reason: Debug session ended with code 9: Terminated due to memory issue.
Recovery Suggestion: Use a memory profiling tool to track the process memory usage.
User Info: {
    DVTErrorCreationDateKey = "2026-05-12 14:02:43 +0000";
    IDERunOperationFailingWorker = DBGLLDBLauncher;
}
--

Event Metadata: com.apple.dt.IDERunOperationWorkerFinished : {
    "device_identifier" = "00008101-00016DEE0C00001E";
    "device_isCoreDevice" = 1;
    "device_model" = "iPhone13,2";
    "device_osBuild" = "26.4.2 (23E261)";
    "device_osBuild_monotonic" = 2304026100;
    "device_os_variant" = 1;
    "device_platform" = "com.apple.platform.iphoneos";
    "device_platform_family" = 2;
    "device_reality" = 1;
    "device_thinningType" = "iPhone13,2";
    "device_transport" = 1;
    "launchSession_schemeCommand" = Run;
    "launchSession_schemeCommand_enum" = 1;
    "launchSession_targetArch" = arm64;
    "launchSession_targetArch_enum" = 6;
    "operation_duration_ms" = 50753;
    "operation_errorCode" = 11;
    "operation_errorDomain" = IDEDebugSessionErrorDomain;
    "operation_errorWorker" = DBGLLDBLauncher;
    "operation_error_reportable" = 0;
    "operation_name" = IDERunOperationWorkerGroup;
    "param_consoleMode" = 1;
    "param_debugger_attachToExtensions" = 0;
    "param_debugger_attachToXPC" = 1;
    "param_debugger_type" = 3;
    "param_destination_isProxy" = 0;
    "param_destination_platform" = "com.apple.platform.iphoneos";
    "param_diag_MTE_enable" = 0;
    "param_diag_MainThreadChecker_stopOnIssue" = 0;
    "param_diag_MallocStackLogging_enableDuringAttach" = 0;
    "param_diag_MallocStackLogging_enableForXPC" = 1;
    "param_diag_allowLocationSimulation" = 1;
    "param_diag_checker_mtc_enable" = 1;
    "param_diag_checker_tpc_enable" = 1;
    "param_diag_gpu_frameCapture_enable" = 0;
    "param_diag_gpu_shaderValidation_enable" = 0;
    "param_diag_gpu_validation_enable" = 0;
    "param_diag_guardMalloc_enable" = 0;
    "param_diag_memoryGraphOnResourceException" = 0;
    "param_diag_queueDebugging_enable" = 1;
    "param_diag_runtimeProfile_generate" = 0;
    "param_diag_sanitizer_asan_enable" = 0;
    "param_diag_sanitizer_tsan_enable" = 0;
    "param_diag_sanitizer_tsan_stopOnIssue" = 0;
    "param_diag_sanitizer_ubsan_enable" = 0;
    "param_diag_sanitizer_ubsan_stopOnIssue" = 0;
    "param_diag_showNonLocalizedStrings" = 0;
    "param_diag_viewDebugging_enabled" = 1;
    "param_diag_viewDebugging_insertDylibOnLaunch" = 1;
    "param_install_style" = 2;
    "param_launcher_UID" = 2;
    "param_launcher_allowDeviceSensorReplayData" = 0;
    "param_launcher_kind" = 0;
    "param_launcher_style" = 99;
    "param_launcher_substyle" = 0;
    "param_lldbVersion_component_idx_1" = 0;
    "param_lldbVersion_monotonic" = 210000170108;
    "param_runnable_appExtensionHostRunMode" = 0;
    "param_runnable_productType" = "com.apple.product-type.application";
    "param_testing_launchedForTesting" = 0;
    "param_testing_suppressSimulatorApp" = 0;
    "param_testing_usingCLI" = 0;
    "sdk_canonicalName" = "iphoneos26.5";
    "sdk_osVersion" = "26.5";
    "sdk_platformID" = 2;
    "sdk_variant" = iphoneos;
    "sdk_version_monotonic" = 2305007300;
}
--


System Information

macOS Version 26.5 (Build 25F71)
Xcode 26.5 (24943) (Build 17F42)
Timestamp: 2026-05-12T22:02:43+08:00
```

The test device is an iPhone 12. Both the App Store version and the version compiled from the latest commit on the main branch have this issue.

https://github.com/user-attachments/assets/0617cccc-5dd0-49ff-86fb-11fde5868610

I also tested an iPhone 15 Pro; the App Store version does not have the crash issue. The iPhone 12 has 4GB of memory, while the iPhone 15 Pro has 8GB. Using the same version (App Store version) on Mac, the peak memory on this page can reach nearly 2GB from an initial 100MB.

Additionally, on macOS, after loading a chart, if I resize the window, various slides in the chart may exhibit sizing errors or inverted directions.

https://github.com/user-attachments/assets/2c798652-458e-4151-9c19-d189b468978a

## Solution

This PR modifies the chart loading logic to use lazy loading. It also modifies the shader to fix the slide issues that occur when the window size changes on macOS.

Additionally, I have reviewed the chart rendering code. If further optimization of memory usage is required, I believe the chart rendering logic can be optimized.

## Testing

* [x] Tested on iPhone 12: The crash no longer occurs.
* [x] Tested on MacBook Air M4 (16GB): The peak memory usage when entering this page dropped from 2GB to approximately 1GB.
* [x] Tested on MacBook Air M4 (16GB): The chart anomaly issue no longer exists after adjusting the window size.